### PR TITLE
Add Vite 3.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pug": "^3.0.2"
   },
   "peerDependencies": {
-    "vite": "^2.5.10"
+    "vite": "^2.5.10 || ^3.0.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
New Vite 3.0 was released.

This plugin works with Vite 3.0 on my projects. 