### PR TITLE
Update regex to allow newline in template tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default function ({ pugOptions = {}, pugLocals = {} } = {}) {
     transformIndexHtml: {
       enforce: 'pre',
       transform(html, { filename }) {
-        const updatedHtml = html.replace(/<template.*?data-type="pug".*?(\/>|<\/template>)/g, (matchedString) => {
+        const updatedHtml = html.replace(/<template(.|\n)*?data-type="pug"(.|\n)*?(\/>|<\/template>)/g, (matchedString) => {
           const [, rawTemplatePath] = matchedString.match(/data-src=["'](.*?)["']/) || [];
 
           if (!rawTemplatePath) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -183,4 +183,39 @@ test('should work multiple templates', () => {
   assert.equal(result, expectedHtml);
 });
 
+test('should when template is on multiple lines', () => {
+  // ARRANGE
+  const rawHtml = `
+    <body>
+      <p>
+        Hello, World!
+          <template
+            data-type="pug"
+            data-src="./template.pug"
+          ></template>
+          <template
+            data-type="pug"
+            data-src="./locals.pug"
+          ></template>
+      </p>
+    </body>
+  `;
+  const expectedHtml = `
+    <body>
+      <p>
+        Hello, World!
+          <p>Pug</p>
+          <p>Vite is the best</p>
+      </p>
+    </body>
+  `;
+
+  // ACTION
+  const result = pugPlugin({ pugLocals: { bundler: 'Vite' } })
+    .transformIndexHtml.transform(rawHtml, { filename: entryFilePath });
+
+  // ASSERT
+  assert.equal(result, expectedHtml);
+});
+
 test.run();


### PR DESCRIPTION
Now `template` tag needs to be written in one line like this: 
`<template data-type="pug" data-src="./template.pug" />`.  

If template tag is split in several lines, the template will not render.

Sometimes this can be a problem because most html tags allow use of multiple line, moreover some formatters, like `prettier` automatically split template tag into several lines if the path to template is long enough. I updated the regex to support `\n` character when parsing the template.|